### PR TITLE
chore: Bump Stryker version to 4.14.0 in CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install tools for coverage and stryker
         run: |
           dotnet tool install -g dotnet-reportgenerator-globaltool --version 5.3.9
-          dotnet tool install -g dotnet-stryker --version 4.13.0
+          dotnet tool install -g dotnet-stryker --version 4.14.0
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
 
       - name: Restore


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow by upgrading the `dotnet-stryker` tool version used for mutation testing.

- CI workflow update:
  * [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL26-R26): Updated the `dotnet-stryker` tool from version 4.13.0 to 4.14.0 to ensure the latest features and fixes are available in the CI pipeline.