### PR TITLE
Fix: add FEATURE_HUB_BYPASS environment variable and implement smoke-…

### DIFF
--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -115,6 +115,7 @@ jobs:
       - name: Start API in background
         env:
           ASPNETCORE_ENVIRONMENT: Development
+          FEATURE_HUB_BYPASS: "true"
         run: |
           nohup dotnet run --project ./server/server.csproj --configuration Release > api.log 2>&1 &
 
@@ -130,6 +131,20 @@ jobs:
           echo "API did not start in time"
           cat api.log
           exit 1
+
+      - name: Smoke-check Task endpoint before k6
+        run: |
+          set -e
+          STATUS_CODE=$(curl -sS -o smoke-response.json -w "%{http_code}" "$API_BASE_URL/api/Task/GetTasks")
+          if [ "$STATUS_CODE" -lt 200 ] || [ "$STATUS_CODE" -ge 300 ]; then
+            echo "Task endpoint smoke check failed with HTTP $STATUS_CODE"
+            echo "--- response body (first 2000 chars) ---"
+            head -c 2000 smoke-response.json || true
+            echo
+            echo "--- api.log (last 200 lines) ---"
+            tail -n 200 api.log || true
+            exit 1
+          fi
 
       - name: Run k6 performance smoke test
         run: BASE_URL="$API_BASE_URL" k6 run ./LoadTesting.Tests/pipeline-smoke.js

--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -134,12 +134,21 @@ jobs:
 
       - name: Smoke-check Task endpoint before k6
         run: |
-          set -e
-          STATUS_CODE=$(curl -sS -o smoke-response.json -w "%{http_code}" "$API_BASE_URL/api/Task/GetTasks")
-          if [ "$STATUS_CODE" -lt 200 ] || [ "$STATUS_CODE" -ge 300 ]; then
-            echo "Task endpoint smoke check failed with HTTP $STATUS_CODE"
+          CURL_EXIT=0
+          STATUS_CODE=$(curl -sS -o smoke-response.json -w "%{http_code}" "$API_BASE_URL/api/Task/GetTasks") || CURL_EXIT=$?
+
+          if [ "$CURL_EXIT" -ne 0 ]; then
+            STATUS_CODE="000"
+          fi
+
+          if [ "$CURL_EXIT" -ne 0 ] || [ "$STATUS_CODE" -lt 200 ] || [ "$STATUS_CODE" -ge 300 ]; then
+            echo "Task endpoint smoke check failed (curl exit: $CURL_EXIT, http: $STATUS_CODE)"
             echo "--- response body (first 2000 chars) ---"
-            head -c 2000 smoke-response.json || true
+            if [ -f smoke-response.json ]; then
+              head -c 2000 smoke-response.json || true
+            else
+              echo "No response body captured."
+            fi
             echo
             echo "--- api.log (last 200 lines) ---"
             tail -n 200 api.log || true


### PR DESCRIPTION
This pull request adds a smoke check to the release gates workflow to improve reliability of the automated deployment pipeline. The main changes ensure that the Task API endpoint is healthy before running performance tests, and that the API starts with the correct feature flag enabled.

**Enhancements to CI workflow:**

* Added the `FEATURE_HUB_BYPASS` environment variable (set to `"true"`) when starting the API in the background, ensuring the correct feature flag is enabled during CI runs.

* Introduced a smoke check step that verifies the `/api/Task/GetTasks` endpoint returns a successful HTTP status code before running k6 performance tests. If the check fails, it outputs the first 2000 characters of the response and the last 200 lines of the API log to aid debugging.