### PR TITLE
Fix: update Vite server configuration to allow access from specific h…

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,10 +4,19 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
+    host: '0.0.0.0',
+    allowedHosts: [
+      'todo.89.117.50.225.nip.io',
+      '89.117.50.225',
+      'localhost',
+      '127.0.0.1',
+      'todo.89.117.49.191.nip.io',
+      '89.117.49.191'  
+    ],
     port: 5173,
     proxy: {
       '/api': {
-        target: 'http://localhost:5000',
+        target: 'http://api:5000',
         changeOrigin: true,
       }
     }


### PR DESCRIPTION
This pull request updates the Vite development server configuration to improve accessibility and environment compatibility. The most important changes include allowing external hosts, updating the API proxy target, and explicitly setting the server host.

Server accessibility and security:

* Added an explicit `host: '0.0.0.0'` setting to allow the dev server to listen on all network interfaces, making it accessible from outside localhost.
* Introduced an `allowedHosts` array to restrict which hosts can access the dev server, including specific IPs and nip.io domains for development and testing.

Development environment configuration:

* Updated the `/api` proxy target from `http://localhost:5000` to `http://api:5000` to support containerized or networked environments where the API is reachable via the `api` hostname.…osts and change API target